### PR TITLE
bump default ylim to 35

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -178,7 +178,7 @@
         legend: {"orientation": "h"},
         yaxis: {
           ticksuffix: "%",
-          range: [0, 30]
+          range: [0, 35]
         },
         xaxis: {
           range: ["2021-10-01", "2022-04-14"] //moment().add(20, 'days').format("YYYY-MM-DD")


### PR DESCRIPTION
this avoids that candidates >= 30% are shown out-of-view when loading the page and resetting the view