### PR TITLE
Fix the title and OpenGraph meta tag contents

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -7,22 +7,17 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>ElecTracker : sondages et résultats des élections régionales 2021</title>
+    <title>ElecTracker : sondages élection présidentielle 2022</title>
     <link rel="icon" type="image/png" href="https://raw.githubusercontent.com/rozierguillaume/electracker/main/img/electracker_logo_transparent.png" />
 
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="@guillaumerozier" />
     <meta name="twitter:creator" content="@guillaumerozier" />
-    <meta property="og:url" content="http://electracker.fr" />
+    <meta property="og:url" content="https://electracker.fr" />
     <meta property="og:title" content="ElecTracker : sondages et résultats des élections" />
     <meta property="og:description" content="ElecTracker est une plateforme citoyenne permettant de consulter les sondages et résultats des élections en France." />
     <meta property="og:image" content="https://raw.githubusercontent.com/rozierguillaume/electracker/main/img/electracker_logo.jpeg" />
-
-    <meta property="og:url"                content="http://electracker.fr" />
-    <meta property="og:type"               content="website" />
-    <meta property="og:title"              content="ElecTracker : sondages et résultats des élections régionales" />
-    <meta property="og:description"        content="ElecTracker est une plateforme citoyenne permettant de consulter les sondages et résultats des élections en France." />
-    <meta property="og:image"              content="https://raw.githubusercontent.com/rozierguillaume/electracker/main/img/electracker_logo.jpeg" />
+    <meta property="og:type" content="website" />
 
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-HFY7GK6QCP"></script>


### PR DESCRIPTION
The main website title was wrong and misleading, and some OpenGraph tags were duplicated.

![image](https://user-images.githubusercontent.com/225704/162387249-5b264a0e-4e9e-4c0d-95f0-405681d6981b.png)
